### PR TITLE
fix: track both PR branch commits and merge commits

### DIFF
--- a/observing/observer/ob_branch.py
+++ b/observing/observer/ob_branch.py
@@ -152,13 +152,17 @@ def find_merged_commits_without_pr(main_repo_name, current_state, previous_state
     pulls = repo.get_pulls(state="closed", base=main_branch_name)
 
     pr_commit_shas = set()
+    pr_merge_commits = set()
+
     for pr in pulls:
         pr_commits = pr.get_commits()
         pr_commit_shas.update(commit.sha for commit in pr_commits)
+        if pr.merge_commit_sha:
+            pr_merge_commits.add(pr.merge_commit_sha)
 
     for commit in new_commits:
         commit_sha = commit.get("sha")
-        if commit_sha and commit_sha not in pr_commit_shas:
+        if commit_sha and commit_sha not in pr_commit_shas and commit_sha not in pr_merge_commits:
             merged_without_pr.append(commit)
 
     return merged_without_pr

--- a/observing/observer/ob_branch.py
+++ b/observing/observer/ob_branch.py
@@ -155,14 +155,16 @@ def find_merged_commits_without_pr(main_repo_name, current_state, previous_state
     pr_merge_commits = set()
 
     for pr in pulls:
-        pr_commits = pr.get_commits()
-        pr_commit_shas.update(commit.sha for commit in pr_commits)
-        if pr.merge_commit_sha:
-            pr_merge_commits.add(pr.merge_commit_sha)
+        if pr.merged and pr.merge_commit_sha:
+            pr_commits = pr.get_commits()
+            pr_commit_shas.update(commit.sha for commit in pr_commits)  # Track commits from merged PRs
+            pr_merge_commits.add(pr.merge_commit_sha)  # Track merge commits
 
     for commit in new_commits:
         commit_sha = commit.get("sha")
-        if commit_sha and commit_sha not in pr_commit_shas and commit_sha not in pr_merge_commits:
+        if (commit_sha and 
+            commit_sha not in pr_commit_shas and 
+            commit_sha not in pr_merge_commits):
             merged_without_pr.append(commit)
 
     return merged_without_pr


### PR DESCRIPTION
fix: track both PR branch commits and merge commits to avoid false po sitives

This addresses: https://github.com/bactensor/github-family-observer/issues/17

When detecting commits merged without PRs, now check both pr.get_commits() and pr.merge_commit_sha to properly handle all PR-related commits.